### PR TITLE
Fix data corruption on get

### DIFF
--- a/conservator-framework/src/ConservatorFramework.cpp
+++ b/conservator-framework/src/ConservatorFramework.cpp
@@ -118,5 +118,5 @@ string ConservatorFramework::get(string path, int length) {
     char buff[length];
     struct Stat stat;
     zoo_get(zk, path.c_str(), 0, buff, &length, &stat);
-    return string(buff);
+    return string(buff, length);
 }

--- a/conservator-framework/src/ConservatorFramework.cpp
+++ b/conservator-framework/src/ConservatorFramework.cpp
@@ -118,5 +118,10 @@ string ConservatorFramework::get(string path, int length) {
     char buff[length];
     struct Stat stat;
     zoo_get(zk, path.c_str(), 0, buff, &length, &stat);
-    return string(buff, length);
+
+    if (length == -1) {
+        return string();
+    } else {
+        return string(buff, length);
+    }
 }

--- a/conservator-framework/src/GetDataBuilderImpl.cpp
+++ b/conservator-framework/src/GetDataBuilderImpl.cpp
@@ -41,6 +41,6 @@ string GetDataBuilderImpl::forPath(string path, int length) {
     if (length == -1) {
         return string();
     } else {
-        return string(buff);
+        return string(buff, length);
     }
 }


### PR DESCRIPTION
The Zoo\* API returns data lengths that don't include the NUL byte, so make sure to construct the string obj with the exact data length. This was corrupting the buffer, largely when a second call was made with a shorter buffer.

I also copied the `length==-1` check to the get() path to ensure we don't fail there if length were returned -1.
