### PR TITLE
add handle() to return zhangle_t, and add output parameter result path for CreateBuilderImpl::forPath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(conservator-framework SHARED
   conservator-framework/src/SetACLBuilderImpl.cpp
   conservator-framework/src/SetACLBuilderImpl.h
   conservator-framework/src/Flagable.h)
+  
+target_link_libraries(conservator-framework zookeeper_mt)
 
 add_subdirectory(conservator-framework/tests)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,6 @@ add_library(conservator-framework SHARED
   conservator-framework/src/SetACLBuilderImpl.cpp
   conservator-framework/src/SetACLBuilderImpl.h
   conservator-framework/src/Flagable.h)
-  
-target_link_libraries(conservator-framework zookeeper_mt)
 
 add_subdirectory(conservator-framework/tests)
 

--- a/conservator-framework/src/ConservatorFramework.h
+++ b/conservator-framework/src/ConservatorFramework.h
@@ -51,6 +51,8 @@ public:
 
     string get(string path);
     string get(string path, int length);
+
+    zhandle_t* handle() { return zk; }
 private:
     zhandle_t *zk;
     string connectString;

--- a/conservator-framework/src/CreateBuilder.h
+++ b/conservator-framework/src/CreateBuilder.h
@@ -15,6 +15,7 @@ public:
     virtual PathableAndWriteable<T> *withFlags(int flags) = 0;
     virtual T forPath(string path) = 0;
     virtual T forPath(string path, const char *data) = 0;
+    virtual T forPath(string path, const char *data, string& result_path) = 0;
 };
 #endif //CONSERVATOR_CREATEBUILDER_H
 

--- a/conservator-framework/src/CreateBuilderImpl.cpp
+++ b/conservator-framework/src/CreateBuilderImpl.cpp
@@ -20,12 +20,22 @@ PathableAndWriteable<int> *CreateBuilderImpl::withFlags(int flags) {
 }
 
 int CreateBuilderImpl::forPath(string path, const char *data) {
-    char buffer[512];
+    string result_path;
+    return this->forPath(path, data, result_path);
+}
+
+int CreateBuilderImpl::forPath(string path, const char *data, string& result_path) {
     int length;
     if (data == NULL) {
         length = -1;
     } else {
         length = char_traits<const char>::length(data);
     }
-    return zoo_create(this->zk, path.c_str(), data, length, &ZOO_OPEN_ACL_UNSAFE, flags, buffer, sizeof(buffer) - 1);
+
+    char buff[512] = {0};
+    int ret = zoo_create(this->zk, path.c_str(), data, length, &ZOO_OPEN_ACL_UNSAFE, flags, buff, sizeof(buff)-1);
+
+    result_path.assign(buff);
+    return ret;
 }
+

--- a/conservator-framework/src/CreateBuilderImpl.h
+++ b/conservator-framework/src/CreateBuilderImpl.h
@@ -20,6 +20,7 @@ public:
     PathableAndWriteable<int>* withFlags(int flags);
     int forPath(string path);
     int forPath(string path, const char *data);
+    int forPath(string path, const char *data, string& result_path);
 private:
     zhandle_t *zk;
     int flags = 0;

--- a/conservator-framework/src/GetChildrenBuilderImpl.cpp
+++ b/conservator-framework/src/GetChildrenBuilderImpl.cpp
@@ -13,18 +13,14 @@ vector<string> GetChildrenBuilderImpl::forPath(string path) {
     if(watcherFn == NULL) {
         zoo_get_children(zk, path.c_str(), -1, &strings);
     } else {
-        printf("Getting children with watch\n");
         zoo_wget_children(zk, path.c_str(), watcherFn, watcherCtx, &strings);
-        printf("Getting children with watch complete\n");
     }
     vector<string> results = vector<string>();
-    printf("strings is %p\n", &strings);
-    printf("strings.count is %d\n", strings.count);
+
     for(int i=0; i<strings.count; i++) {
         results.push_back(string(strings.data[i]));
     }
 
-    printf("returning results of %p\n", &results);
     return results;
 }
 

--- a/conservator-framework/src/PathableAndWriteable.h
+++ b/conservator-framework/src/PathableAndWriteable.h
@@ -14,6 +14,7 @@ class PathableAndWriteable {
 public:
     virtual T forPath(string path) = 0;
     virtual T forPath(string path, const char *data) = 0;
+    virtual T forPath(string path, const char *data, string& result_path) = 0;
 };
 
 

--- a/conservator-framework/src/SetDataBuilder.h
+++ b/conservator-framework/src/SetDataBuilder.h
@@ -19,6 +19,7 @@ public:
     virtual ~SetDataBuilder() {};
     virtual T forPath(string path) = 0;
     virtual T forPath(string path, const char *data) = 0;
+    virtual T forPath(string path, const char *data, string&) = 0;
     virtual PathableAndWriteable<T>* withVersion(int version) = 0;
 };
 #endif //CONSERVATOR_SETDATABUILDER_H

--- a/conservator-framework/src/SetDataBuilderImpl.cpp
+++ b/conservator-framework/src/SetDataBuilderImpl.cpp
@@ -23,6 +23,10 @@ ZOOAPI int SetDataBuilderImpl::forPath(string path, const char *data) {
     return zoo_set(zk, path.c_str(), data, length, version);
 }
 
+ZOOAPI int SetDataBuilderImpl::forPath(string path, const char *data, string&) {
+    return this->forPath(path, data);
+}
+
 PathableAndWriteable<int>* SetDataBuilderImpl::withVersion(int version) {
     this->version = version;
     return (PathableAndWriteable<int> *) this;

--- a/conservator-framework/src/SetDataBuilderImpl.h
+++ b/conservator-framework/src/SetDataBuilderImpl.h
@@ -18,6 +18,7 @@ public:
     SetDataBuilderImpl(zhandle_t *zk);
     ZOOAPI int forPath(string path);
     ZOOAPI int forPath(string path, const char *data);
+    ZOOAPI int forPath(string path, const char *data, string&);
     PathableAndWriteable<int>* withVersion(int version);
 private:
     zhandle_t *zk = NULL;


### PR DESCRIPTION
1. add handle() to return zhangle_t, 
   so user can call zoo_* functions exposed by zookeeper.h, such as zoo_client_id.

2. and add output parameter result path for CreateBuilderImpl::forPath
  so user can create ZOO_SEQUENCE node, and get the result znode path.